### PR TITLE
dev-ml/lwt-2.5.0[ssl] requires >dev-ml/ocaml-ssl-0.4.7 to build

### DIFF
--- a/dev-ml/lwt/lwt-2.5.0.ebuild
+++ b/dev-ml/lwt/lwt-2.5.0.ebuild
@@ -18,7 +18,7 @@ IUSE="gtk +react +ssl"
 
 DEPEND="react? ( >=dev-ml/react-1.2:= )
 	dev-libs/libev
-	ssl? ( >=dev-ml/ocaml-ssl-0.4.0:= )
+	ssl? ( >=dev-ml/ocaml-ssl-0.5.1:= )
 	gtk? ( dev-ml/lablgtk:= dev-libs/glib:2 )
 	|| ( dev-ml/camlp4:= <dev-lang/ocaml-4.02.0 )"
 


### PR DESCRIPTION
This fixes build issue [#559352](https://bugs.gentoo.org/show_bug.cgi?id=559352). I didn't make it -r1 because
(1) it doesn't require a rebuild for existing merges
(2) it just fixes dependency issues in case of unsuccessful merges/compile failures
(3) effectively no changes are made to working installs

Please merge into the tree.
